### PR TITLE
small fix for endless jump (using mouse button)

### DIFF
--- a/Assets/Scripts/PlayerControl.cs
+++ b/Assets/Scripts/PlayerControl.cs
@@ -64,7 +64,7 @@ public class PlayerControl : MonoBehaviour
 		    jumpTimeCounter = JUMP_TIME;
 		}
 
-		if (grounded && Input.GetKeyDown(KeyCode.Space) || Input.GetMouseButtonDown(0))
+		if (grounded && (Input.GetKeyDown(KeyCode.Space) || Input.GetMouseButtonDown(0)))
 		{
 		    initialJump = true;
 		}


### PR DESCRIPTION
Fixed Endless repeated jump (when using mouse) which was possible because of missing round brackets.